### PR TITLE
Logic for root placeholders with path-based routing (en → en sheet, fr → fr sheet)

### DIFF
--- a/blocks/featured-projects/featured-projects.js
+++ b/blocks/featured-projects/featured-projects.js
@@ -1,10 +1,11 @@
 import { fetchPlaceholders } from '../../scripts/aem.js';
 import { getLanguage } from '../../scripts/scripts.js';
 
+
 export default async function decorate(block) {
   const template = block.querySelector('div > div')?.textContent?.trim();
 
-  const placeholders = await fetchPlaceholders(`/${getLanguage()}`);
+  const placeholders = await fetchPlaceholders(`${getLanguage()}`);
 
   // Create the heading based on template
   const heading = document.createElement('h2');

--- a/blocks/featured-projects/featured-projects.js
+++ b/blocks/featured-projects/featured-projects.js
@@ -1,7 +1,6 @@
 import { fetchPlaceholders } from '../../scripts/aem.js';
 import { getLanguage } from '../../scripts/scripts.js';
 
-
 export default async function decorate(block) {
   const template = block.querySelector('div > div')?.textContent?.trim();
 

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -534,11 +534,11 @@ function decorateSections(main) {
  * @returns {object} Window placeholders object
  */
 // eslint-disable-next-line import/prefer-default-export
-async function fetchPlaceholders(prefix = 'default') {
+async function fetchPlaceholders(prefix = 'en') {
   window.placeholders = window.placeholders || {};
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
+      fetch(`/placeholders.json?sheet=${prefix}`)
         .then((resp) => {
           if (resp.ok) {
             return resp.json();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #69 

Test URLs:
- Before: https://main--fondationsaudemarspiguet--aemdemos.aem.live/fr/fondation-pour-les-arbres-actualites/education-et-resilience-la-jeunesse-ougandaise-a-lepreuve-du
- After: https://issue69-placeholder--fondationsaudemarspiguet--aemdemos.aem.live/fr/fondation-pour-les-arbres-actualites/education-et-resilience-la-jeunesse-ougandaise-a-lepreuve-du
- https://main--fondationsaudemarspiguet--aemdemos.aem.page/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
- https://issue69-placeholder--fondationsaudemarspiguet--aemdemos.aem.page/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
