### PR TITLE
fix: enforce transform image url to root-relative url

### DIFF
--- a/tools/importer/transformers/images.js
+++ b/tools/importer/transformers/images.js
@@ -22,8 +22,8 @@ function adjustImageUrls(main, url, current) {
         new URL(src);
       } catch (e) {
         if (!src.startsWith('/')) {
-          // enforce transform image url to relative url
-          src = `./${src}`;
+          // enforce transform image url to root-relative url
+          src = `/${src}`;
         }
       }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #311 

Test URLs:
- Before: https://main--fondationsaudemarspiguet--aemdemos.aem.live/
- After: https://issue-311--fondationsaudemarspiguet--aemdemos.aem.live/
