### PR TITLE
Remove CSS rules dependent on these BG class variants for News & Map pages

### DIFF
--- a/templates/map-landing/map-landing.css
+++ b/templates/map-landing/map-landing.css
@@ -64,6 +64,9 @@ body.biencommun.map-landing main .default-content-wrapper p.button-container a.b
 
 body.map-landing .section.pale-grey-bg {
     background-color: var(--news-bg-page);
+}
+
+body.map-landing .section.map-container {
     padding: 0;
     margin: 0;
 }
@@ -72,7 +75,7 @@ body.biencommun .section.pale-grey-bg {
     background-color: var(--map-bg-page-bien);
 }
 
-body.map-landing .section.pale-grey-bg .cards-wrapper {
+body.map-landing .section.map-container .cards-wrapper {
     display: grid;
     grid-template-columns: auto;
     grid-template-rows: auto;
@@ -85,12 +88,12 @@ body.map-landing .section.pale-grey-bg .cards-wrapper {
     margin: 0;
 }
 
-body.map-landing.biencommun .section.pale-grey-bg .cards-wrapper {
+body.map-landing.biencommun .section.map-container .cards-wrapper {
     background-color: var(--map-carte-icone-container-bien);
 }
 
 
-body.map-landing .section.pale-grey-bg .map-wrapper {
+body.map-landing .section.map-container .map-wrapper {
     height: 1064.44px;
     position: relative;
     overflow: hidden;
@@ -99,7 +102,7 @@ body.map-landing .section.pale-grey-bg .map-wrapper {
     max-width: 100%;
 }
 
-body.map-landing .section.pale-grey-bg .map-bien-wrapper {
+body.map-landing .section.map-container .map-bien-wrapper {
     height: 1064.44px;
     position: relative;
     overflow: hidden;
@@ -109,7 +112,7 @@ body.map-landing .section.pale-grey-bg .map-bien-wrapper {
 }
 
 @media (width >= 900px) {
-    body.map-landing .section.pale-grey-bg .cards-wrapper {
+    body.map-landing .section.map-container .cards-wrapper {
         height: 1064.44px;
         width: 250px;
         float: left;

--- a/templates/news-article/news-article.css
+++ b/templates/news-article/news-article.css
@@ -2,16 +2,18 @@ body.news-article main .carousel-wrapper {
     padding-top: 30px;
 }
 
-
 body.news-article main .section.white-smoke-bg {
     background-color: var(--news-bg-page);
+}
+
+body.news-article main .section.articleintro-container + div {
     color: var(--news-sophis-intro);
     padding: 60px 0;
     text-align: center;
     margin: 0;
 }
 
-body.biencommun main .section.white-smoke-bg {
+body.biencommun main .section.articleintro-container + div {
     color: var(--biencommun-news-sophis-intro);
 }
 
@@ -19,12 +21,12 @@ body.news-article main .section.featured-projects-container {
     padding-bottom: 30px;
 }
 
-body.news-article main .section.white-smoke-bg .default-content-wrapper {
+body.news-article main .section.articleintro-container + div .default-content-wrapper {
     max-width: unset;
     margin: auto;
 }
 
-body.news-article main .section.white-smoke-bg .default-content-wrapper p {
+body.news-article main .section.articleintro-container + div .default-content-wrapper p {
     font-size: 24px;
     max-width: 90%;
     position: relative;
@@ -289,7 +291,7 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
         float: left;
     }
 
-    body.news-article main .section.white-smoke-bg .default-content-wrapper p {
+    body.news-article main .section.articleintro-container + div .default-content-wrapper p {
         font-size: 40px;
     }
 
@@ -318,7 +320,7 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
 }
 
 @media (width >= 900px) {
-    body.news-article main .section.white-smoke-bg .default-content-wrapper p {
+    body.news-article main .section.articleintro-container + div .default-content-wrapper p {
         font-size: 40px;
         max-width: 48%;
         top: unset;
@@ -349,7 +351,7 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
 }
 
 @media (width >= 1200px) {
-    body.news-article main .section.white-smoke-bg .default-content-wrapper p {
+    body.news-article main .section.articleintro-container + div .default-content-wrapper p {
         font-size: 40px;
         max-width: 48%;
         top: unset;

--- a/templates/news-article/news-article.css
+++ b/templates/news-article/news-article.css
@@ -38,44 +38,50 @@ body.news-article main .section.articleintro-container + div .default-content-wr
 
 body.news-article main .section.details-sidebar.light-grey-bg + * {
     background-color: var(--news-bg-page-suite);
+}
+
+body.news-article main .section.details-sidebar + * {
     margin: 0;
   }
 
-body.biencommun main .section.details-sidebar.light-grey-bg + * {
+body.biencommun main .section.details-sidebar + * {
     background-color: unset;
 }
 
 body.news-article main .section.white-lilac-bg {
     background-color: var(--news-sophis-bg-text2);
+}
+
+body.news-article main .section.articlecontent-container + div {
     padding: 40px 0 0;
     margin: 0 0 40px;
 }
 
-body.news-article main .section.white-lilac-bg div.default-content-wrapper {
+body.news-article main .section.articlecontent-container + div div.default-content-wrapper {
     float: right;
     padding: 0 20px;
 }
 
-body.news-article main .section.white-lilac-bg div.default-content-wrapper > p {
+body.news-article main .section.articlecontent-container + div div.default-content-wrapper > p {
     line-height: 1.5em;
     letter-spacing: .04em;
     font-size: 14px;
 }
 
-body.news-article main .section.white-lilac-bg div.default-content-wrapper > p > strong {
+body.news-article main .section.articlecontent-container + div div.default-content-wrapper > p > strong {
     color: var(--news-category);
     font-weight: bold;
 }
 
-body.biencommun main .section.white-lilac-bg div.default-content-wrapper > p > strong {
+body.biencommun main .section.articlecontent-container + div div.default-content-wrapper > p > strong {
     color: var(--biencommun-projet-bloc-titre);
 }
 
-body.biencommun main .section.white-lilac-bg div.default-content-wrapper a:any-link {
+body.biencommun main .section.articlecontent-container + div div.default-content-wrapper a:any-link {
     color: var(--site-color-2-bien);
 }
 
-body.news-article main .section.white-lilac-bg div.image-wrapper {
+body.news-article main .section.articlecontent-container + div div.image-wrapper {
     padding-top: 40px;
     margin-bottom: 40px;
     float: right;
@@ -83,11 +89,11 @@ body.news-article main .section.white-lilac-bg div.image-wrapper {
     padding-right: unset;
 }
 
-body.news-article main .section.white-lilac-bg div.image-wrapper p {
+body.news-article main .section.articlecontent-container + div div.image-wrapper p {
     margin-top: 0;
 }
 
-body.news-article main .section.white-lilac-bg div.image-wrapper img {
+body.news-article main .section.articlecontent-container + div div.image-wrapper img {
     vertical-align: bottom;
 }
 
@@ -295,22 +301,22 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
         font-size: 40px;
     }
 
-    body.news-article main .section.white-lilac-bg {
+    body.news-article main .section.articlecontent-container + div {
         padding: 90px 0 0;
         margin: 0 0 50px;
     }
 
-    body.news-article main .section.white-lilac-bg div.default-content-wrapper {
+    body.news-article main .section.articlecontent-container + div div.default-content-wrapper {
         width: calc(100% - 280px);
         box-sizing: border-box;
     }
 
-    body.news-article main .section.white-lilac-bg div.image-wrapper {
+    body.news-article main .section.articlecontent-container + div div.image-wrapper {
         padding-top: 15px;
         margin-bottom: 0;
     }
 
-    body.news-article main .section.white-lilac-bg div.image-wrapper p {
+    body.news-article main .section.articlecontent-container + div div.image-wrapper p {
         margin-bottom: 0;
     }
 
@@ -326,12 +332,12 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
         top: unset;
     }
 
-    body.news-article main .section.white-lilac-bg div.default-content-wrapper {
+    body.news-article main .section.articlecontent-container + div div.default-content-wrapper {
         padding: 0 80px;
         width: calc(100% - 380px);
     }
 
-    body.news-article main .section.white-lilac-bg div.default-content-wrapper > p {
+    body.news-article main .section.articlecontent-container + div div.default-content-wrapper > p {
         font-size: 20px;
     }
 
@@ -357,16 +363,16 @@ body.news-article main .section.details-sidebar.right .news-article-inner .defau
         top: unset;
     }
 
-    body.news-article main .section.white-lilac-bg {
+    body.news-article main .section.articlecontent-container + div {
         margin: 0 0 140px;
     }
 
-    body.news-article main .section.white-lilac-bg div.default-content-wrapper {
+    body.news-article main .section.articlecontent-container + div div.default-content-wrapper {
         max-width: 900px;
         box-sizing: unset;
     }
 
-    body.news-article main .section.white-lilac-bg div.image-wrapper {
+    body.news-article main .section.articlecontent-container + div div.image-wrapper {
         margin-bottom: -90px;
         max-width: unset;
     }

--- a/templates/news-article/news-article.js
+++ b/templates/news-article/news-article.js
@@ -100,16 +100,16 @@ export default async function decorate(doc) {
   }
   // Add a clear div after the first paragraph to ensure the second paragraph
   // remains in the float: right position for large screen sizes
-  const textPara = doc.querySelector('.section.white-lilac-bg .default-content-wrapper p:first-of-type');
+  const textPara = doc.querySelector('.section.articlecontent-container + div .default-content-wrapper p:first-of-type');
   const clearDiv = div({ class: 'clear' });
   if (textPara) {
     textPara.insertAdjacentElement('afterend', clearDiv);
   }
 
   // Move text content and image content to be encased by different divs
-  const whiteLilacSection = doc.querySelector('.section.white-lilac-bg');
-  const allParas = doc.querySelectorAll('.section.white-lilac-bg div > p');
-  const defaultDiv = doc.querySelector('.section.white-lilac-bg div.default-content-wrapper');
+  const whiteLilacSection = doc.querySelector('.section.articlecontent-container + div');
+  const allParas = doc.querySelectorAll('.section.articlecontent-container + div div > p');
+  const defaultDiv = doc.querySelector('.section.articlecontent-container + div div.default-content-wrapper');
   const ImageDiv = document.createElement('div');
   ImageDiv.className = 'image-wrapper';
 
@@ -137,8 +137,8 @@ export default async function decorate(doc) {
   }
 
   // apply fade out animation to news detail section
-  const pictureEl = doc.querySelector('.section.white-lilac-bg div.image-wrapper p picture');
-  const imagePara = doc.querySelector('.section.white-lilac-bg div.image-wrapper p');
+  const pictureEl = doc.querySelector('.section.articlecontent-container + div div.image-wrapper p picture');
+  const imagePara = doc.querySelector('.section.articlecontent-container + div div.image-wrapper p');
   if (pictureEl && imagePara) {
     applyFadeUpAnimation(pictureEl, imagePara);
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #480 

Test URLs:
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
- After: https://issue480--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/new-forest-reserve-in-the-parc-naturel-du-jorat
- After: https://issue480--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/new-forest-reserve-in-the-parc-naturel-du-jorat
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-projects-map
- After: https://issue480--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-projects-map
