### PR TITLE
Instrumenting logic for covering data-background attribute with its r…

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,5 +1,3 @@
-import { applySectionBackgrounds } from './utils.js';
-
 export default function loadswiper() {
   return new Promise((resolve, reject) => {
     // Check if Swiper is already loaded
@@ -37,6 +35,3 @@ export default function loadswiper() {
     document.head.append(scriptrrule);
   });
 }
-
-// Apply section backgrounds after delay to avoid performance impact
-applySectionBackgrounds();

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,3 +1,5 @@
+import { applySectionBackgrounds } from './utils.js';
+
 export default function loadswiper() {
   return new Promise((resolve, reject) => {
     // Check if Swiper is already loaded
@@ -35,3 +37,6 @@ export default function loadswiper() {
     document.head.append(scriptrrule);
   });
 }
+
+// Apply section backgrounds after delay to avoid performance impact
+applySectionBackgrounds();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,7 +16,7 @@ import {
   toCamelCase,
   fetchPlaceholders,
 } from './aem.js';
-import { decorateListingCards } from './utils.js';
+import { decorateListingCards, applySectionBackgrounds } from './utils.js';
 
 const LANGUAGES = new Set(['en', 'fr']);
 let language;
@@ -584,6 +584,9 @@ function backToTopWithIcon() {
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
   await loadSections(main);
+
+  // Apply section backgrounds after all sections are loaded and decorated
+  await applySectionBackgrounds();
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -103,3 +103,75 @@ export function setInputWidthToText(inputEl) {
   spanForWidth.remove();
   inputEl.style.width = `${width}px`;
 }
+
+export async function setClassDataBg() {
+  try {
+    const response = await fetch('/.da/library/blocks.json');
+    if (!response.ok) {
+      return null;
+    }
+
+    const jsonData = await response.json();
+
+    // Find the background option in the options.data array
+    const backgroundOption = jsonData.options?.data?.find(
+      (item) => item.key === 'background',
+    );
+
+    if (!backgroundOption || !backgroundOption.values) {
+      return null;
+    }
+
+    // Parse the values string into an object
+    const backgroundValues = {};
+    const valuesString = backgroundOption.values;
+
+    // Split by " | " and parse each background value
+    const valuesList = valuesString.split(' | ').map((val) => val.trim());
+
+    valuesList.forEach((valueItem) => {
+      // Parse format like "cream-bg=#f8f7f2"
+      const [name, colorCode] = valueItem.split('=');
+      if (name && colorCode) {
+        backgroundValues[name.trim()] = colorCode.trim();
+      }
+    });
+
+    return backgroundValues;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function applySectionBackgrounds() {
+  try {
+    // Get the background values from the JSON
+    const backgroundValues = await setClassDataBg();
+    if (!backgroundValues) {
+      return;
+    }
+
+    // Find all divs with class "section" that have "data-background" attribute
+    const sectionsWithDataBackground = document.querySelectorAll('.section[data-background]');
+
+    sectionsWithDataBackground.forEach((sectionDiv) => {
+      const dataBackgroundValue = sectionDiv.getAttribute('data-background');
+      if (!dataBackgroundValue) return;
+
+      // Find matching background value in our backgroundValues object
+      const matchingKey = Object.keys(backgroundValues).find(
+        (key) => backgroundValues[key] === dataBackgroundValue,
+      );
+
+      if (matchingKey) {
+        // Check if the div already has this class
+        if (!sectionDiv.classList.contains(matchingKey)) {
+          // Add the background class
+          sectionDiv.classList.add(matchingKey);
+        }
+      }
+    });
+  } catch (error) {
+    // Silent error handling
+  }
+}


### PR DESCRIPTION
Instrumenting logic for covering data-background attribute with its respective class names

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #537 

Test URLs:
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/drafts/meet/
- After: https://issuebg--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/drafts/meet/
