### PR TITLE
Adding flavors of fonts types to match the news right section

### DIFF
--- a/blocks/articlecontent/articlecontent.css
+++ b/blocks/articlecontent/articlecontent.css
@@ -94,13 +94,22 @@ body.biencommun .articlecontent.block .news-detail-big-contenu-right {
 }
 
 .articlecontent.block .news-detail-big-contenu-right p strong {
-    color: #D3C19B;
     line-height: 1.5em;
     padding-bottom: 20px;
     letter-spacing: .02em;
     font-size: 14px;
     font-weight: 300;
     font-weight: bold !important;
+    color: var(--background-color);
+}
+
+.articlecontent.block .news-detail-big-contenu-right p strong em {
+    font-style: normal;
+    color: var(--biencommun-carousel-color);
+}
+
+.articlecontent.block .news-detail-big-contenu-right p strong u {
+    color: var(--site-color-2);
 }
 
 .articlecontent.block .news-detail-big-contenu-right > p:first-child {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #602 

Test URLs:
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
- After: https://issue602--arbres-fondationsaudemarspiguet--audemars-piguet.aem.live/en/fondation-pour-les-arbres-news/education-and-resilience-future-proofing-the-youth-of-uganda
