### PR TITLE
removing extra padding on news page

### DIFF
--- a/blocks/featured-projects/featured-projects.css
+++ b/blocks/featured-projects/featured-projects.css
@@ -1,7 +1,8 @@
 /* featured-projects.css */
 .featured-projects.block {
     margin-bottom: 50px;
-    margin-top: 50px;
+    
+    /* margin-top: 50px; */
 }
 
 .featured-projects.block .cards.block.featured ul {
@@ -101,9 +102,9 @@
 }
 
 @media (width >= 600px) {
-    .featured-projects.block {
+    /* .featured-projects.block {
         margin-top: 100px;
-    }
+    } */
 
     .featured-projects.block .cards.block.featured ul {
         grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #618 

Test URLs:
- Before: https://main--arbres-fondationsaudemarspiguet--audemars-piguet.aem.page/en/fondation-pour-les-arbres-news/on-the-trail-of-resonance-wood
- After:  https://issue-618--arbres-fondationsaudemarspiguet--audemars-piguet.aem.page/en/fondation-pour-les-arbres-news/on-the-trail-of-resonance-wood
